### PR TITLE
[fix] typography 관련 클래스명 오류

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -81,47 +81,47 @@
 /* 커스텀 클래스 정의 */
 @layer utilities {
   /* Typography 정의 */
-  .text-title1 {
+  .typo-title1 {
     @apply text-[2.25rem] leading-[120%] font-bold;
   }
 
-  .text-h1 {
+  .typo-h1 {
     @apply text-[1.75rem] leading-[130%] font-bold;
   }
 
-  .text-h2 {
+  .typo-h2 {
     @apply text-[1.5rem] leading-[130%] font-bold;
   }
 
-  .text-h3 {
+  .typo-h3 {
     @apply text-[1.25rem] leading-[130%] font-bold;
   }
 
-  .text-body1 {
+  .typo-body1 {
     @apply text-[1.25rem] leading-[140%] font-normal tracking-[-0.75%];
   }
 
-  .text-body2 {
+  .typo-body2 {
     @apply text-[1.125rem] leading-[140%] font-normal tracking-[-0.75%];
   }
 
-  .text-body3 {
+  .typo-body3 {
     @apply text-[1rem] leading-[140%] font-normal tracking-[-0.75%];
   }
 
-  .text-button1 {
+  .typo-button1 {
     @apply text-[1rem] leading-[120%] font-bold;
   }
 
-  .text-button2 {
+  .typo-button2 {
     @apply text-[0.875rem] leading-[120%] font-bold;
   }
 
-  .text-caption1 {
+  .typo-caption1 {
     @apply text-[0.875rem] leading-[140%] font-normal;
   }
 
-  .text-caption2 {
+  .typo-caption2 {
     @apply text-[0.75rem] leading-[140%] font-normal;
   }
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

#23 

## 📝 요약

typography 설정한 클래스명이 tailwind의 기본 텍스트컬러 클래스와 중복되어 적용되지 않음

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명해주세요)

## 📸 스크린샷 (선택)

## 💬 리뷰어에게 공유사항

- 기존 text- prefix를 typo- 로 수정

## ✅ PR 체크리스트

- [x] 커밋 메시지 컨벤션을 따랐습니다.
- [ ] 변경 사항에 대한 테스트를 수행했습니다.
- [ ] 관련 문서를 업데이트했습니다.
